### PR TITLE
fix: Updated base image in order to also run VirtualAvr on aarch64 machines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:20-alpine
 
 RUN apk add --no-cache bash socat curl gcc-avr g++ gcompat libc6-compat websocat
 RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=/usr/local/bin sh


### PR DESCRIPTION
It seems the previous base image does not work on Mac machines with M-chip ... however simply updating to a more recent base image resolved that issue for me.